### PR TITLE
Fix container name check

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func getDockerContainerAddresses() ([]string, error) {
 
 	dockerAddresses := []string{}
 	for _, container := range containers {
-		if !strings.Contains(container.Names[0], "quotient_runner_") {
+		if !strings.Contains(container.Names[0], "quotient-runner-") {
 			continue
 		}
 


### PR DESCRIPTION
Docker compose v2 changed the container naming scheme to use `-` instead of `_`, which breaks the `getDockerContainerAddresses()` function.

See https://docs.docker.com/compose/releases/migrate/#service-container-names